### PR TITLE
Update JVM to current java and windows

### DIFF
--- a/.vscode/symbols.json
+++ b/.vscode/symbols.json
@@ -1,0 +1,1 @@
+{"symbols":{},"files":{}}

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ Navigate to `./platforms/windows/bin` and run `uninstall.ps1` in Powershell to u
 - Installing the latest version of Java (v16): `jvm install latest`
 - Installing a specific version of Java: `jvm install #` (e.g. `jvm install 8`)
 > Note, this command will not automatically set your version to the newly installed version. That needs to be done in the next step.
+- List all installed version: `jvm list`
 - Switch to another installed version: `jvm use #` (e.g. `jvm use 8`)
 
 ## Attribution
-- The compressed binaries for Java v9 to Java v16 are provided by [OpenJDK](https://openjdk.java.net/)
-- The Java v8 compressed binaries for linux are provided by the developer of this tool, which was originally sourced from OpenJDK.
+- The compressed binaries for Java v8 to Java v19 are provided by [OpenJDK](https://openjdk.java.net/)
 
 ## Platform Support
-- Ubuntu v19 and v20 (suspected to be compatible will all Linux distributions)
-- Windows 10
-- Windows Server 2019
+- Ubuntu v22 (suspected to be compatible will all Linux distributions)
+- Windows 11
+- Windows Server 2022
 
 ## Limitations
 - No support for Java v10 on Windows

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `jvm` (Java Version Manager)
+# `JVM` (Java Version Manager)
 
 A simple command line tool for installing and switching between JDK versions.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Navigate to `./platforms/windows/bin` and run `uninstall.ps1` in Powershell to u
 - Windows Server 2022
 
 ## Limitations
-- No support for Java v10 on Windows
+- No support for Java v10 on Windows (due to licence agreements)
 - No support for Java v7 or below
 - Does not work correctly with Git Bash for Windows

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Navigate to `./platforms/windows/bin` and run `uninstall.ps1` in Powershell to u
 
 ---
 ## Usage
-- Installing the latest version of Java (v16): `jvm install latest`
+- Installing the latest version of Java (v19): `jvm install latest`
 - Installing a specific version of Java: `jvm install #` (e.g. `jvm install 8`)
 > Note, this command will not automatically set your version to the newly installed version. That needs to be done in the next step.
 - List all installed version: `jvm list`

--- a/platforms/linux/bin/jvm
+++ b/platforms/linux/bin/jvm
@@ -84,6 +84,14 @@ javaVersion=$2
 
 case $cmd in
 
+    list)
+        echo "jvm: Listing installed Java versions..."
+        echo "jvm: Installed versions:"
+        for dir in $jvm/installed-versions/*; do
+            echo "jvm:   `basename $dir`"
+        done
+        ;;
+
     install)
         case $javaVersion in
         
@@ -269,7 +277,7 @@ case $cmd in
         ;;
 
     *)
-        printf "usage: jvm [command] [version]\n\nCommands: use, install, uninstall"
+        printf "usage: jvm [command] [version]\n\nCommands: use, list, install, uninstall"
 	    echo
     
 esac

--- a/platforms/linux/bin/jvm
+++ b/platforms/linux/bin/jvm
@@ -234,6 +234,6 @@ case $cmd in
 
     *)
         printf "usage: jvm [command] [version]\n\nCommands: use, install, uninstall"
-	echo
+	    echo
     
 esac

--- a/platforms/linux/bin/jvm
+++ b/platforms/linux/bin/jvm
@@ -87,40 +87,52 @@ case $cmd in
     install)
         case $javaVersion in
         
-            latest | 16)
-                install-jdk 16 https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz
+            latest | 19)
+                install-jdk 19 https://download.java.net/openjdk/jdk19/ri/openjdk-19+36_linux-x64_bin.tar.gz
+                ;;
+            
+            18)
+                install-jdk 18 https://download.java.net/openjdk/jdk18/ri/openjdk-18+36_linux-x64_bin.tar.gz
+                ;;
+            
+            17)
+                install-jdk 17 https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_linux-x64_bin.tar.gz
+                ;;
+            
+            16)
+                install-jdk 16 https://download.java.net/openjdk/jdk16/ri/openjdk-16+36_linux-x64_bin.tar.gz
                 ;;
             
             15)
-                install-jdk 15 https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz
+                install-jdk 15 https://download.java.net/openjdk/jdk15/ri/openjdk-15+36_linux-x64_bin.tar.gz
                 ;;
             
             14)
-                install-jdk 14 https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz
+                install-jdk 14 https://download.java.net/openjdk/jdk14/ri/openjdk-14+36_linux-x64_bin.tar.gz
                 ;;
             
             13)
-                install-jdk 13 https://download.java.net/java/GA/jdk13.0.2/d4173c853231432d94f001e99d882ca7/8/GPL/openjdk-13.0.2_linux-x64_bin.tar.gz
+                install-jdk 13 https://download.java.net/openjdk/jdk13/ri/openjdk-13+33_linux-x64_bin.tar.gz
                 ;;
                 
             12)
-                install-jdk 12 https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+                install-jdk 12 https://download.java.net/openjdk/jdk12/ri/openjdk-12+32_linux-x64_bin.tar.gz
                 ;;
 
             11)
-                install-jdk 11 https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+                install-jdk 11 https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
                 ;;
                 
             10)
-                install-jdk 10 https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz
+                install-jdk 10 https://download.java.net/openjdk/jdk10/ri/openjdk-10+44_linux-x64_bin_ri.tar.gz
                 ;;
                 
             9)
-                install-jdk 9 https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz
+                install-jdk 9 https://download.java.net/openjdk/jdk9/ri/openjdk-9+181_linux-x64_ri.zip
                 ;;
                 
             8)
-                install-jdk 8 https://innov8dev-resources.s3.amazonaws.com/openjdk-8.tar.gz
+                install-jdk 8 https://download.java.net/openjdk/jdk8u42/ri/openjdk-8u42-b03-linux-x64-14_jul_2022.tar.gz
                 ;;
                 
             7 | 6 | 5 | 4 | 3 | 2 | 1)
@@ -137,7 +149,19 @@ case $cmd in
     use)
         case $javaVersion in
         
-            latest | 16)
+            latest | 19)
+                change-jdk 19
+                ;;
+
+            18)
+                change-jdk 18
+                ;;
+
+            17)
+                change-jdk 17
+                ;;
+
+            16)
                 change-jdk 16
                 ;;
             
@@ -186,7 +210,19 @@ case $cmd in
     uninstall)
         case $javaVersion in
         
-            latest | 16)
+            latest | 19)
+                rm -Rf ~/.jvm/installed-versions/open-jdk-19
+                ;;
+            
+            18)
+                rm -Rf ~/.jvm/installed-versions/open-jdk-18
+                ;;
+            
+            17)
+                rm -Rf ~/.jvm/installed-versions/open-jdk-17
+                ;;
+            
+            16)
                 rm -Rf ~/.jvm/installed-versions/open-jdk-16
                 ;;
             
@@ -207,19 +243,19 @@ case $cmd in
                 ;;
 
             11)
-		rm -Rf ~/.jvm/installed-versions/open-jdk-11
+		        rm -Rf ~/.jvm/installed-versions/open-jdk-11
                 ;;
                 
             10)
-		rm -Rf ~/.jvm/installed-versions/open-jdk-10
+		        rm -Rf ~/.jvm/installed-versions/open-jdk-10
                 ;;
                 
             9)
-		rm -Rf ~/.jvm/installed-versions/open-jdk-9
+		        rm -Rf ~/.jvm/installed-versions/open-jdk-9
                 ;;
                 
             8)
-		rm -Rf ~/.jvm/installed-versions/open-jdk-8
+		        rm -Rf ~/.jvm/installed-versions/open-jdk-8
                 ;;
                 
             7 | 6 | 5 | 4 | 3 | 2 | 1)

--- a/platforms/linux/bin/jvm
+++ b/platforms/linux/bin/jvm
@@ -234,5 +234,6 @@ case $cmd in
 
     *)
         printf "usage: jvm [command] [version]\n\nCommands: use, install, uninstall"
+	echo
     
 esac

--- a/platforms/windows/bin/install.ps1
+++ b/platforms/windows/bin/install.ps1
@@ -10,6 +10,7 @@ mkdir ~\.jvm\current\bin | Out-Null
 
 # Copy jvm file to created bin directory and make it an executable
 Copy-Item .\jvm.ps1 ~\.jvm\bin\jvm.ps1
+Copy-Item .\jvm.bat ~\.jvm\bin\jvm.bat
 
 # change file ACL permissions for user
 $acl = Get-Acl .\jvm.ps1

--- a/platforms/windows/bin/jvm.bat
+++ b/platforms/windows/bin/jvm.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell -command "jvm  %*"

--- a/platforms/windows/bin/jvm.ps1
+++ b/platforms/windows/bin/jvm.ps1
@@ -99,7 +99,16 @@ switch ($cmd) {
     install {
         switch ($javaVersion) {
             latest {
-                Install-JDK latest https://download.java.net/openjdk/jdk16/ri/openjdk-16+36_windows-x64_bin.zip
+                Install-JDK latest https://download.java.net/openjdk/jdk19/ri/openjdk-19+36_windows-x64_bin.zip
+            }
+            19 {
+                Install-JDK 19 https://download.java.net/openjdk/jdk19/ri/openjdk-19+36_windows-x64_bin.zip
+            }
+            18 {
+                Install-JDK 18 https://download.java.net/openjdk/jdk18/ri/openjdk-18+36_windows-x64_bin.zip
+            }
+            17 {
+                Install-JDK 17 https://download.java.net/openjdk/jdk17/ri/openjdk-17+35_windows-x64_bin.zip
             }
             16 {
                 Install-JDK 16 https://download.java.net/openjdk/jdk16/ri/openjdk-16+36_windows-x64_bin.zip
@@ -127,7 +136,7 @@ switch ($cmd) {
                 Install-JDK 9 https://download.java.net/openjdk/jdk9/ri/jdk-9+181_windows-x64_ri.zip
             }
             8 {
-                Install-JDK 8 https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-windows-i586-14_jan_2020.zip
+                Install-JDK 8 https://download.java.net/openjdk/jdk8u42/ri/openjdk-8u42-b03-windows-i586-14_jul_2022.zip
             }
             { $_ -lt 8 } {
                 Write-Output "jvm: No support for Java version 7 and below"
@@ -141,6 +150,15 @@ switch ($cmd) {
         switch ($javaVersion) {
             latest {
                 Set-JDK latest
+            }
+            19 {
+                Set-JDK 19
+            }
+            18 {
+                Set-JDK 18
+            }
+            17 {
+                Set-JDK 17
             }
             16 {
                 Set-JDK 16
@@ -182,7 +200,7 @@ switch ($cmd) {
             latest {
                 Remove-Item -Recurse -Force "$jvm\installed-versions\open-jdk-latest"
             }
-            { $_ -lt 17 -And $_ -gt 7} {
+            { $_ -lt 20 -And $_ -gt 7} {
                 Remove-Item -Recurse -Force "$jvm\installed-versions\open-jdk-$_"
             }
             { $_ -lt 8 } {

--- a/platforms/windows/bin/jvm.ps1
+++ b/platforms/windows/bin/jvm.ps1
@@ -42,14 +42,15 @@ function Install-JDK {
                 Exit-Error "Failed to download JDK zip from $downloadLink! Aborting installation!"
             }
             Write-Output "Attempting to extract the archive"
-            $extracted = (Expand-Archive -PassThru -Path $zipped -DestinationPath "$jvm\tmp" -EA SilentlyContinue -EV err)
+		Expand-Archive -Path $zipped -DestinationPath "$jvm\tmp" -EA SilentlyContinue -EV err
+            $extracted = (Get-ChildItem -Path "$jvm\tmp" -Directory -Filter *$version* | Select-Object -ExpandProperty FullName)
             if ($err -gt 0) {
                 Exit-Error "Failed to unzip JDK tarball! Aborting installation!"
             }
-        } catch [ParameterBindingValidationException] {
+        } catch {
             Write-Error "There was an issue resolving a parameter within the script. `nThis is normally caused by the archive module not being updated. `nRun Install-Module Microsoft.Powershell.Archive -Force in admin mode to resolve the issue. `nIf the issue does not subside, submit an issue to the GitHub Repository."
-        }
-        mkdir $versionDir
+        	Write-Host $_
+	  }
         Copy-Item -Recurse -Force $extracted $versionDir
         Remove-Item -Recurse -Force (Resolve-Path ~\.jvm\tmp\*)
         Write-Output "jvm: Java v$version installed!"

--- a/platforms/windows/bin/jvm.ps1
+++ b/platforms/windows/bin/jvm.ps1
@@ -96,6 +96,13 @@ $cmd = $args[0]
 $javaVersion = $args[1]
 
 switch ($cmd) {
+    list {
+        Write-Output "jvm: Listing installed Java versions..."
+        Write-Output "jvm: Installed versions:"
+        Get-ChildItem -Path "$jvm\installed-versions" -Directory | ForEach-Object {
+            Write-Output "jvm:   $(Split-Path $_ -Leaf)"
+        }
+    }
     install {
         switch ($javaVersion) {
             latest {
@@ -212,6 +219,6 @@ switch ($cmd) {
         }
     }
     Default {
-        Write-Output "usage: jvm [command] [version]`n`nCommands: use, install, uninstall"
+        Write-Output "usage: jvm [command] [version]`n`nCommands: use, list, install, uninstall"
     }
 }


### PR DESCRIPTION
JVM is a great tool, wish it would get more used. But sadly jvm is not compatible with windows 11 (due to small powershell changes). This Pull request aims to update the whole tool to current java versions and fixing windows compatibilty.

Following changes were made:
- Linux new Line fix 
- Update Java download links
- Add new Java versions
- FIx Compatiblity with Win 11 due to Expand-Archive changes
- Add CMD support via batchfile calling ps1 script
- Add list command